### PR TITLE
Change Overlay Panel

### DIFF
--- a/src/components/common-functions.ts
+++ b/src/components/common-functions.ts
@@ -33,6 +33,16 @@ export function generateNumberArray<T>(
   return numberArray;
 }
 
+export function isEventOutsideTarget(event: Event, target: HTMLElement) {
+  const eventElement = event.target as HTMLElement;
+
+  if (eventElement) {
+    return !target.isSameNode(eventElement) && !target.contains(eventElement);
+  }
+
+  return false;
+}
+
 export function isEventWithinTarget(event: Event, target: HTMLElement) {
   const testElement = event.target as HTMLElement;
   return testElement ? isElementWithinTarget(testElement, target) : false;


### PR DESCRIPTION
Changed the overlay panel to used fixed positioning instead of absolute, so I can remove React.createPortal. This fixes an issue where the date/time is used inside an overlay panel and selecting a date causes the parent overlay panel to close.