### PR TITLE
Clear onChange

### DIFF
--- a/src/components/form/date-time/date-time.component.tsx
+++ b/src/components/form/date-time/date-time.component.tsx
@@ -213,6 +213,8 @@ export default function DateTime({
       dispatcher({
         type: DateTimeActionType.ClearDates,
       });
+
+      onChange?.();
     }
   };
 


### PR DESCRIPTION
Fired the `onChange` event when the date is cleared so when the component is used in a form the value can be cleared out.