### PR TITLE
Fix Library Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Publish package to GitHub Packages
         run: yarn publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "main": "build/index.cjs.js",
   "module": "build/index.min.js",
-  "types": "types/src/index.d.ts",
+  "types": "build/types/src/index.d.ts",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-regular-svg-icons": "^6.4.0",


### PR DESCRIPTION
The build has started putting the types folder inside the build folder instead of at the root of the library.