### PR TITLE
Fix formatted input onChange

### DIFF
--- a/src/components/form/input/formatted-input/parser/format-parser.ts
+++ b/src/components/form/input/formatted-input/parser/format-parser.ts
@@ -79,6 +79,7 @@ export class FormatParser implements IDisposable {
         this.inputRuleProcessor.processInputValue(inputValue);
       } else {
         this.inputSlotCollection.clearAllSlots();
+        this.previousOutputValue = undefined;
       }
 
       // setTimeout is used because this is usually called after the input element has been created. This is a good
@@ -87,6 +88,10 @@ export class FormatParser implements IDisposable {
         this.formatRenderer.render();
         if (this.isInputFocused) {
           this.formatNavigator.setCursorToCurrentPosition();
+        }
+
+        if (this.inputValue.length > 0) {
+          this.previousOutputValue = this.inputElement?.innerHTML;
         }
       });
     }


### PR DESCRIPTION
Fixed an issue in the formatted input where selecting a date from the selector and then clearing the date only works the first time. This was because the `previousOutputValue` wasn't being set when a date was selected, only when a date was typed in by hand.