### PR TITLE
BSC-27 - Fix Time Selector

### DIFF
--- a/src/components/form/date-time/date-time-time-selector.component.tsx
+++ b/src/components/form/date-time/date-time-time-selector.component.tsx
@@ -175,7 +175,7 @@ const DateTimeTimeSelector = ({
             <ArrowUpSLineIcon />
           </Button>
         </div>
-        <div>&nbsp;</div>
+        <div></div>
         <div className="bc-dt-time-minute-increase bsc-cursor-pointer bsc-text-center">
           <Button className="bsc-bg-transparent bsc-p-2 focus:bsc-outline-none" onClick={increaseMinute}>
             <ArrowUpSLineIcon />
@@ -199,7 +199,7 @@ const DateTimeTimeSelector = ({
             <ArrowDownSLineIcon />
           </Button>
         </div>
-        <div>&nbsp;</div>
+        <div></div>
         <div className="bc-dt-time-minute-decrease bsc-cursor-pointer bsc-text-center">
           <Button className="bsc-bg-transparent bsc-p-2 focus:bsc-outline-none" onClick={decreaseMinute}>
             <ArrowDownSLineIcon />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,10 +3,6 @@ export default {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   prefix: 'bsc-',
   darkMode: 'class', // or 'media' or 'class'
-  corePlugins: {
-    // due to https://github.com/tailwindlabs/tailwindcss/issues/6602 - buttons disappear
-    preflight: false,
-  },
   theme: {
     colors: {
       transparent: 'transparent',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,16 @@ export default defineConfig({
       insertTypesEntry: true,
     }),
     gzipPlugin(),
+    {
+      name: 'remove-bg-transparent',
+      transform(src, id) {
+        if (id.includes('beesoft-components/src/index.css')) {
+          return {
+            code: src.replace(/(background-color:\s?transparent;)/, '/* $1 */ '),
+          };
+        }
+      },
+    },
   ],
   build: {
     lib: {


### PR DESCRIPTION
Removed the non-breaking space from the time selector which will hopefully removing the strange character being displayed in a compiled site. Also fixed the `background-color: transparent` issue by creating a custom Vite plugin to remove that line.