### PR TITLE
BSC-46 - Add Close on Selection Feature

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Publish to Chromatic
-        run: bunx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded
-      - name: Upload Logs
-        uses: actions/upload-artifact@v3
-        if: ${{ !cancelled() }}
+        uses: chromaui/action@v9
         with:
-          name: external-logs
-          path: /home/runner/work/beesoft-components/beesoft-components/**/*.log
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitOnceUploaded: true
+        env:
+          ACTIONS_STEP_DEBUG: true

--- a/src/common/hooks/use-state-ref.ts
+++ b/src/common/hooks/use-state-ref.ts
@@ -1,6 +1,17 @@
-import { useRef, useState } from 'react';
+import { Dispatch, MutableRefObject, SetStateAction, useRef, useState } from 'react';
 
-const useStateRef = <T>(initialState?: T) => {
+type UseStateRef = {
+  <T>(initialState: T): readonly [T, Dispatch<SetStateAction<T>>, MutableRefObject<T>];
+  <T = undefined>(): readonly [T | undefined, Dispatch<SetStateAction<T | undefined>>, MutableRefObject<T | undefined>];
+};
+
+/**
+ * A hook that uses both a state and ref variable and keeps both in sync. This is useful when state variables are
+ * causing closure issues in certain functions.
+ * @param {T} initialState - The initial value to set the state and ref to.
+ * @returns {readonly [T | undefined, <T>(value: ((<T>(prevState: (T | undefined)) => (T | undefined)) | T | undefined)) => void, React.MutableRefObject<T | undefined>]}
+ */
+const useStateRef: UseStateRef = <T>(initialState?: T) => {
   const [state, setState] = useState(initialState);
   const ref = useRef(initialState);
 

--- a/src/components/form/checkboxes/checkbox/checkbox.component.tsx
+++ b/src/components/form/checkboxes/checkbox/checkbox.component.tsx
@@ -32,7 +32,7 @@ const CheckboxComponent = (props: CheckboxProps, ref: Ref<CheckboxRef>) => {
 
   useEffect(() => {
     setCheckedState({
-      checked: partial ? true : checkedState ? checkedState.checked : false,
+      checked: partial ? true : checkedState.checked,
       partial,
     });
   }, [partial]);
@@ -124,12 +124,12 @@ const CheckboxComponent = (props: CheckboxProps, ref: Ref<CheckboxRef>) => {
           id={id}
           name={name}
           type="checkbox"
-          checked={checkedState?.checked}
+          checked={checkedState.checked}
           onChange={handleChangeEvent}
           className={innerCheckboxStyles}
         />
         <svg viewBox="0 0 21 21" className={svgStyles}>
-          {!checkedState?.partial ? <polyline points="5 10.75 8.5 14.25 16 6" /> : <polyline points="6 10.5 16 10.5" />}
+          {!checkedState.partial ? <polyline points="5 10.75 8.5 14.25 16 6" /> : <polyline points="6 10.5 16 10.5" />}
         </svg>
       </label>
       {labelLocation === CheckboxLabelLocation.Right && (

--- a/src/components/form/date-time/date-time-calendar.component.tsx
+++ b/src/components/form/date-time/date-time-calendar.component.tsx
@@ -190,16 +190,16 @@ const DateTimeCalendar = ({
   };
 
   const defaultTemplate = (_props: DateTimeCalendarTemplateProps, children: ReactNode | Array<ReactNode>) => (
-    <div className="bsc-w-full bc-dt-calendar">{children}</div>
+    <div className="bc-dt-calendar bsc-w-full">{children}</div>
   );
 
   const template = viewTemplate || defaultTemplate;
 
   return (
     <TemplateOutlet props={templateProps} template={template}>
-      <div className="bsc-grid bsc-grid-cols-7 bsc-gap-3 bc-dt-day-row bsc-min-w-[329px]">
+      <div className="bc-dt-day-row bsc-grid bsc-min-w-[329px] bsc-grid-cols-7 bsc-gap-3">
         {weekDaysRef.current?.map((day, index) => (
-          <div key={index} className="bsc-text-center bsc-font-bold bc-dt-day-cell">
+          <div key={index} className="bc-dt-day-cell bsc-text-center bsc-font-bold">
             {day}
           </div>
         ))}

--- a/src/components/form/date-time/date-time-day-selector.component.tsx
+++ b/src/components/form/date-time/date-time-day-selector.component.tsx
@@ -70,7 +70,7 @@ const DateTimeDaySelector = ({
   };
 
   return (
-    <div className="bsc-p-2 bc-dt-day-selector">
+    <div className="bc-dt-day-selector bsc-p-2">
       <DateTimeScroller
         title={getCurrentMonthYear()}
         scrollerType={DateScrollerType.Day}
@@ -88,9 +88,9 @@ const DateTimeDaySelector = ({
         dispatcher={dispatcher}
       />
       {showTimeSelector && (
-        <div className="bsc-w-full bsc-flex bsc-flex-row bsc-p-2 bsc-justify-center bc-dt-time-value-wrapper">
+        <div className="bc-dt-time-value-wrapper bsc-flex bsc-w-full bsc-flex-row bsc-justify-center bsc-p-2">
           <div
-            className="bsc-p-2 bsc-cursor-pointer hover:bsc-bg-gray-4 dark:hover:bsc-bg-mono-light-2 dark:hover:bsc-text-mono-dark-2 dark:bsc-bg-mono-dark-1 dark:bsc-text-mono-light-1 bc-dt-time-value"
+            className="bc-dt-time-value bsc-cursor-pointer bsc-p-2 hover:bsc-bg-gray-4 dark:bsc-bg-mono-dark-1 dark:bsc-text-mono-light-1 dark:hover:bsc-bg-mono-light-2 dark:hover:bsc-text-mono-dark-2"
             onClick={onTimeClicked}
           >
             {selectedDate?.toLocaleTimeString(locale.code) || getDefaultTime(locale)}

--- a/src/components/form/date-time/date-time.component.stories.tsx
+++ b/src/components/form/date-time/date-time.component.stories.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react';
 import { forceAssert } from '../../common-functions.ts';
 import { Button } from '../../navigation/buttons/button/button.component.tsx';
 import { CalendarIconPosition, DateFormatType, DateSelectionType } from './date-time-types.ts';
-import DateTime, { DateTimeInputTemplateProps, DateTimeProps } from './date-time.component.tsx';
+import { DateTime } from './date-time.component.tsx';
+import { DateTimeInputTemplateProps, DateTimeProps } from './date-time.props.ts';
 
 const meta: Meta<typeof DateTime> = {
   title: 'Form/Date Time',
@@ -273,6 +274,37 @@ export const Formatted24TimeInput: Story = {
     dateSelection: DateSelectionType.TimeOnly,
     locale: 'de-DE',
     useFormattedInput: true,
+    onChange: action('onChange'),
+  },
+  render: (args) => <Template {...args} />,
+};
+
+export const CloseOnSelection: Story = {
+  args: {
+    label: 'Date',
+    closeSelector: true,
+    dateSelection: DateSelectionType.DateOnly,
+    onChange: action('onChange'),
+  },
+  render: (args) => <Template {...args} />,
+};
+
+export const CloseOnSelectionInvalidDate: Story = {
+  args: {
+    label: 'Date (Australia Day 2024 Invalid)',
+    closeSelector: true,
+    dateSelection: DateSelectionType.DateOnly,
+    isValidDate: (date) => !(date.getFullYear() === 2024 && date.getMonth() === 0 && date.getDate() === 26),
+    onChange: action('onChange'),
+  },
+  render: (args) => <Template {...args} />,
+};
+
+export const CloseOnSelectionNotDateOnly: Story = {
+  args: {
+    label: 'Date',
+    closeSelector: true,
+    dateSelection: DateSelectionType.DateTime,
     onChange: action('onChange'),
   },
   render: (args) => <Template {...args} />,

--- a/src/components/form/date-time/date-time.component.tsx
+++ b/src/components/form/date-time/date-time.component.tsx
@@ -4,73 +4,24 @@ import { debounce } from 'lodash-es';
 import React, { ReactNode, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { getBrowserLanguage } from '../../common-functions';
 import { TypeOrArray } from '../../common-interfaces.ts';
-import TemplateOutlet, { TemplateFunction } from '../../common/template-outlet/template-outlet.component';
+import TemplateOutlet from '../../common/template-outlet/template-outlet.component';
 import { Calendar2LineIcon, CloseLineIcon } from '../../icons.ts';
 import { MediaQuery } from '../../mobile/media-query/media-query.component.tsx';
 import { MobileOverlayPanel } from '../../mobile/overlay/mobile-overlay-panel.component.tsx';
 import OverlayPanel from '../../overlay/overlay-panel/overlay-panel.component';
-import { FormInputControl } from '../form-control.interface';
 import ContentEditableInput from '../inputs/content-editable-input/content-editable-input.component';
 import FormattedInput from '../inputs/formatted-input/formatted-input.component';
-import { DateTimeCalendarTemplate } from './date-time-calendar.component';
 import { DateTimeContext, DateTimeContextProps } from './date-time-context';
 import DateTimeDaySelector from './date-time-day-selector.component';
 import { isDateBetween, loadLocale, parseDate, parseDateRange } from './date-time-functions';
 import DateTimeMonthSelector from './date-time-month-selector.component';
 import DateTimeRangeSelector from './date-time-range-selector.component';
-import { DateTimeScrollerTemplate } from './date-time-scroller.component';
 import DateTimeTimeSelector from './date-time-time-selector.component';
-import {
-  CalendarIconPosition,
-  DateFormatType,
-  DateSelectionType,
-  TimeConstraints,
-  TimeFormatType,
-} from './date-time-types';
+import { CalendarIconPosition, DateFormatType, DateSelectionType, TimeFormatType } from './date-time-types';
 import DateTimeYearSelector from './date-time-year-selector.component';
+import { DateTimeInputTemplateProps, DateTimeProps } from './date-time.props.ts';
 import reducer, { DateTimeActionType, DateTimeState } from './date-time.reducer';
 import useGetDateTimeFormat from './hooks/get-date-time-format.hook';
-
-export interface DateTimeProps extends FormInputControl<string | TypeOrArray<Date>, TypeOrArray<Date>> {
-  useDefaultDateValue?: boolean;
-  useFormattedInput?: boolean;
-  allowClear?: boolean;
-  locale?: string;
-  dateSelection?: DateSelectionType;
-  dateFormat?: DateFormatType;
-  timeConstraints?: TimeConstraints;
-  icon?: React.JSX.Element;
-  iconPosition?: CalendarIconPosition;
-  inputElement?: HTMLElement;
-  /**
-   * If the passed function returns false then that date will not be selectable and will be marked with the error style.
-   * @param {Date} currentDate - The date to test.
-   * @returns {boolean} false indicates the date should not be selectable.
-   */
-  selectableDate?: (currentDate: Date) => boolean;
-  /**
-   * If the passed function returns false then the date will not be selected in the input.
-   * @param {Date} selectedDate - The selected date to test.
-   * @returns {boolean} false indicates the date is not valid.
-   */
-  isValidDate?: (selectedDate: Date) => boolean;
-  calendarTemplate?: DateTimeCalendarTemplate;
-  dateScrollerTemplate?: DateTimeScrollerTemplate;
-  inputTemplate?: DateTimeInputTemplate;
-}
-
-export interface DateTimeInputTemplateProps {
-  label?: string;
-  readOnly: boolean;
-  allowClear: boolean;
-  getValue: () => string;
-  onFocus: (event: FocusEvent) => void;
-  onInput: (event: React.FormEvent) => void;
-  iconPosition: CalendarIconPosition;
-  iconElement?: React.JSX.Element;
-}
-
-export type DateTimeInputTemplate = TemplateFunction<DateTimeInputTemplateProps>;
 
 const DateTime = ({
   value,
@@ -79,6 +30,7 @@ const DateTime = ({
   useDefaultDateValue = false,
   useFormattedInput = false,
   allowClear = false,
+  closeSelector = false,
   locale,
   className,
   dateSelection = DateSelectionType.DateTime,
@@ -294,6 +246,14 @@ const DateTime = ({
     }
   };
 
+  const onDateSelectorChange = (value?: TypeOrArray<Date>) => {
+    if (dateSelection === DateSelectionType.DateOnly && closeSelector === true) {
+      setSelectorOpen(false);
+    }
+
+    onChange?.(value);
+  };
+
   const onCalendarIconClick = () => {
     setDropDownElement();
     setSelectorOpen(!selectorOpen);
@@ -474,7 +434,7 @@ const DateTime = ({
             selectableDate={selectableDate}
             isValidDate={isValidDate}
             dispatcher={dispatcher}
-            onChange={onChange}
+            onChange={onDateSelectorChange}
           />
         )}
       {state.currentSelector === DateTimeActionType.MonthSelector &&
@@ -631,4 +591,4 @@ const DateTime = ({
   );
 };
 
-export default DateTime;
+export { DateTime };

--- a/src/components/form/date-time/date-time.props.ts
+++ b/src/components/form/date-time/date-time.props.ts
@@ -1,0 +1,53 @@
+import React from 'react';
+import { TypeOrArray } from '../../common-interfaces.ts';
+import { TemplateFunction } from '../../common/template-outlet/template-outlet.component.tsx';
+import { FormInputControl } from '../form-control.interface.ts';
+import { DateTimeCalendarTemplate } from './date-time-calendar.component.tsx';
+import { DateTimeScrollerTemplate } from './date-time-scroller.component.tsx';
+import { CalendarIconPosition, DateFormatType, DateSelectionType, TimeConstraints } from './date-time-types.ts';
+
+export interface DateTimeProps extends FormInputControl<string | TypeOrArray<Date>, TypeOrArray<Date>> {
+  useDefaultDateValue?: boolean;
+  useFormattedInput?: boolean;
+  allowClear?: boolean;
+  /**
+   * When true the date selector will close when a valid date selection is made. This will only affect the "date only"
+   * selector (default false).
+   */
+  closeSelector?: boolean;
+  locale?: string;
+  dateSelection?: DateSelectionType;
+  dateFormat?: DateFormatType;
+  timeConstraints?: TimeConstraints;
+  icon?: React.JSX.Element;
+  iconPosition?: CalendarIconPosition;
+  inputElement?: HTMLElement;
+  /**
+   * If the passed function returns false then that date will not be selectable and will be marked with the error style.
+   * @param {Date} currentDate - The date to test.
+   * @returns {boolean} false indicates the date should not be selectable.
+   */
+  selectableDate?: (currentDate: Date) => boolean;
+  /**
+   * If the passed function returns false then the date will not be selected in the input.
+   * @param {Date} selectedDate - The selected date to test.
+   * @returns {boolean} false indicates the date is not valid.
+   */
+  isValidDate?: (selectedDate: Date) => boolean;
+  calendarTemplate?: DateTimeCalendarTemplate;
+  dateScrollerTemplate?: DateTimeScrollerTemplate;
+  inputTemplate?: DateTimeInputTemplate;
+}
+
+export interface DateTimeInputTemplateProps {
+  label?: string;
+  readOnly: boolean;
+  allowClear: boolean;
+  getValue: () => string;
+  onFocus: (event: FocusEvent) => void;
+  onInput: (event: React.FormEvent) => void;
+  iconPosition: CalendarIconPosition;
+  iconElement?: React.JSX.Element;
+}
+
+export type DateTimeInputTemplate = TemplateFunction<DateTimeInputTemplateProps>;

--- a/src/components/form/date-time/date-time.reducer.ts
+++ b/src/components/form/date-time/date-time.reducer.ts
@@ -107,7 +107,7 @@ const reducer = (state: DateTimeState, action: DateTimeReducerAction): DateTimeS
         timeFormat: state.timeFormat,
         dateInitialized: true,
       };
-    case DateTimeActionType.InitializeDates:
+    case DateTimeActionType.InitializeDates: {
       const baseState = {
         ...state,
         currentViewDate: getInitialDate(action.initialDate),
@@ -126,6 +126,7 @@ const reducer = (state: DateTimeState, action: DateTimeReducerAction): DateTimeS
           selectedEndDate: action.initialDate[1],
         };
       }
+    }
     default:
       return {
         ...state,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,18 @@
 // components
 import { Button } from './components/navigation/buttons/button/button.component.tsx';
 import ContentEditableInput from './components/form/inputs/content-editable-input/content-editable-input.component';
-import DateTime from './components/form/date-time/date-time.component';
+import { DateTime } from './components/form/date-time/date-time.component';
 import FormattedInput from './components/form/inputs/formatted-input/formatted-input.component';
-import OverlayPanel from './components/overlay/overlay-panel/overlay-panel.component';
 import { MediaQuery } from './components/mobile/media-query/media-query.component.tsx';
 import { MobileOverlayPanel } from './components/mobile/overlay/mobile-overlay-panel.component.tsx';
+import OverlayPanel from './components/overlay/overlay-panel/overlay-panel.component';
 
 // functions
 import { createBeeSoftTheme, applyBeeSoftTheme } from './components/common-functions';
 
 // types
-import { DateSelectionType } from './components/form/date-time/date-time-types';
-import { DateTimeInputTemplateProps } from './components/form/date-time/date-time.component';
+import { DateFormatType, DateSelectionType } from './components/form/date-time/date-time-types';
+import { DateTimeInputTemplateProps } from './components/form/date-time/date-time.props.ts';
 import { DateTimeScrollerTemplateProps } from './components/form/date-time/date-time-scroller.component';
 import { DateTimeCalendarTemplateProps } from './components/form/date-time/date-time-calendar.component';
 
@@ -27,13 +27,14 @@ export {
   MediaQuery,
   MobileOverlayPanel,
   OverlayPanel,
+
+  // functions
   applyBeeSoftTheme,
   createBeeSoftTheme,
+
+  // types to be used as values
+  DateFormatType,
+  DateSelectionType,
 };
 
-export type {
-  DateSelectionType,
-  DateTimeInputTemplateProps,
-  DateTimeScrollerTemplateProps,
-  DateTimeCalendarTemplateProps,
-};
+export type { DateTimeInputTemplateProps, DateTimeScrollerTemplateProps, DateTimeCalendarTemplateProps };


### PR DESCRIPTION
Added the close on selection feature to the date component; this closes the date selector when a valid selection has been made when the component is in `DateOnly` mode. Also fixed the `useStateRef` hook to not make the state variable potentially undefined when a value is passed. Lastly trying again to get the Chromatic build working on each commit.