### PR TITLE
BSC-55 - Fix partial checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beesoft-components",
-  "version": "0.6.2",
+  "version": "0.6.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "beesoft-components",
-      "version": "0.6.2",
+      "version": "0.6.3-0",
       "license": "MIT",
       "dependencies": {
         "@react-hook/media-query": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beesoft-components",
-  "version": "0.6.2",
+  "version": "0.6.3-0",
   "private": false,
   "type": "module",
   "author": {

--- a/src/components/form/checkboxes/checkbox/checkbox.component.stories.tsx
+++ b/src/components/form/checkboxes/checkbox/checkbox.component.stories.tsx
@@ -33,14 +33,13 @@ const ContextNoAnimationTemplate = (args: CheckboxProps) => (
   </BeeSoftProvider>
 );
 
-const PartialTemplate = (args: CheckboxProps) => {
+const PartialCheckedTemplate = (args: CheckboxProps) => {
   document.body.className = '';
 
-  const [partial, setPartial] = useState(args.partial || false);
   const checkboxRef = useRef<CheckboxRef>(null);
 
-  const onPartialClicked = () => {
-    setPartial(!partial);
+  const onCheckedRefClicked = () => {
+    checkboxRef.current?.setChecked(true);
   };
 
   const onPartialRefClicked = () => {
@@ -51,8 +50,8 @@ const PartialTemplate = (args: CheckboxProps) => {
     <div className="bsc-w-full">
       <div className="bsc-mb-2 bsc-flex bsc-w-full">
         <div className="bsc-flex-1">
-          <Button buttonType="primary" onClick={onPartialClicked}>
-            Set Partial
+          <Button buttonType="primary" onClick={onCheckedRefClicked}>
+            Set Checked with Ref
           </Button>
         </div>
         <div className="bsc-flex-1">
@@ -62,7 +61,7 @@ const PartialTemplate = (args: CheckboxProps) => {
         </div>
       </div>
       <div className="bsc-p-2">
-        <Checkbox ref={checkboxRef} {...args} partial={partial} />
+        <Checkbox ref={checkboxRef} {...args} />
       </div>
     </div>
   );
@@ -171,7 +170,7 @@ export const Partial: Story = {
     value: 'test',
     partial: true,
   },
-  render: (args) => <PartialTemplate {...args} />,
+  render: (args) => <PartialCheckedTemplate {...args} />,
 };
 
 export const Dark: Story = {

--- a/src/components/form/checkboxes/checkbox/checkbox.component.tsx
+++ b/src/components/form/checkboxes/checkbox/checkbox.component.tsx
@@ -78,16 +78,18 @@ const CheckboxComponent = (props: CheckboxProps, ref: Ref<CheckboxRef>) => {
     };
 
     setCheckedState(state);
+  };
 
-    onChange?.({
-      ...state,
-      name,
-      value,
+  const setChecked = (checked: boolean) => {
+    setCheckedState({
+      checked,
+      partial: false,
     });
   };
 
   useImperativeHandle(ref, () => ({
     setPartiallyChecked,
+    setChecked,
   }));
 
   const wrapperStyles = cx(

--- a/src/components/form/checkboxes/checkbox/checkbox.props.ts
+++ b/src/components/form/checkboxes/checkbox/checkbox.props.ts
@@ -19,4 +19,5 @@ export interface CheckboxProps extends FormInputControl<unknown, CheckboxChangeE
 
 export interface CheckboxRef {
   setPartiallyChecked: (partiallyChecked: boolean) => void;
+  setChecked: (checked: boolean) => void;
 }


### PR DESCRIPTION
Removed the code that fires the `onChange` event when partial is set programmatically and added a way to set the checkbox to checked again programmatically.