### PR TITLE
BSC-83: Fix Custom Icons

### DIFF
--- a/src/components/form/date-time/date-time.component.tsx
+++ b/src/components/form/date-time/date-time.component.tsx
@@ -392,13 +392,12 @@ const DateTime = ({
                     />
                   </div>
                 )}
-                <div className="bsc-ml-2">
+                <div className="bsc-ml-2" onClick={!readOnly ? onCalendarIconClick : undefined}>
                   {icon || (
                     <BeeSoftIcon
                       icon="calendar"
                       size={IconSize.Small}
                       className={!readOnly ? 'bsc-cursor-pointer' : undefined}
-                      onClick={!readOnly ? onCalendarIconClick : undefined}
                     />
                   )}
                 </div>
@@ -409,13 +408,12 @@ const DateTime = ({
         : {
             leftElement: (
               <div className="bsc-flex bsc-text-black dark:bsc-text-mono-light-1">
-                <div className="bsc-mr-2">
+                <div className="bsc-mr-2" onClick={!readOnly ? onCalendarIconClick : undefined}>
                   {icon || (
                     <BeeSoftIcon
                       icon="calendar"
                       size={IconSize.Small}
                       className={!readOnly ? 'bsc-cursor-pointer' : undefined}
-                      onClick={!readOnly ? onCalendarIconClick : undefined}
                     />
                   )}
                 </div>


### PR DESCRIPTION
Moved the `onClick` event handler to the wrapper element, so custom icons will still open the overlay panel correctly.