### PR TITLE
BSC-113 - Avatar Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Moved the code that generates the preview on file load into the loading function to try and fix a minor issue.
+
 ## [0.12.1] - 2026-01-20
 
 ## Changed

--- a/src/components/miscellaneous/avatar-editor/avatar-editor.component.tsx
+++ b/src/components/miscellaneous/avatar-editor/avatar-editor.component.tsx
@@ -62,12 +62,6 @@ const AvatarEditor = ({
     }
   }, [source]);
 
-  useEffect(() => {
-    if (!showFileLoader && showPreviewOnFileLoad) {
-      onEdit?.(createPreviewImage());
-    }
-  }, [showFileLoader]);
-
   const loadImage = (imageData: string) => {
     const image = new Image();
     image.crossOrigin = 'Anonymous';
@@ -132,6 +126,10 @@ const AvatarEditor = ({
     setImageWidth(finalWidth);
     setImageHeight(finalHeight);
     setLoadedImage(image);
+
+    if (showPreviewOnFileLoad) {
+      onEdit?.(createPreviewImage());
+    }
   };
 
   const scaledRadius = (scale = 0) => {


### PR DESCRIPTION
Changed where `showPreviewOnFileLoad` is called from. This should fix the issue where loading a second file doesn't show the preview immediately.