### PR TITLE
BSC-116 - Force Time Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Added a `timeFormat` property to allow the user to manually set 12 or 24 hour time formats.
+
 ## [0.12.3] - 2026-02-11
 
 ## Changed

--- a/src/components/form/date-time/date-time-format-creator.ts
+++ b/src/components/form/date-time/date-time-format-creator.ts
@@ -1,5 +1,5 @@
 import { FormatPart, FormatValueType, InputFormat } from '../inputs/formatted-input/input-format.interfaces';
-import { DateSelectionType } from './date-time-types';
+import { DateSelectionType, TimeFormatType } from './date-time-types';
 
 export class DateTimeFormatCreator {
   private readonly dateFormat: string;
@@ -20,7 +20,8 @@ export class DateTimeFormatCreator {
 
   constructor(
     private dateSelection: DateSelectionType,
-    localeCode: string
+    localeCode: string,
+    timeFormat?: TimeFormatType
   ) {
     const year = 2023;
     const month = 12;
@@ -41,9 +42,12 @@ export class DateTimeFormatCreator {
     time.setHours(hour, minute, second, milliseconds);
 
     const testTimeFormat = time.toLocaleTimeString(localeCode);
-    this.use24HourTime = testTimeFormat.startsWith('18');
+    const isLocale24HourTime = testTimeFormat.startsWith('18');
+    this.use24HourTime = timeFormat === undefined
+      ? isLocale24HourTime
+      : timeFormat === TimeFormatType.TwentyFourHour;
     this.timeFormat = testTimeFormat
-      .replace(`${this.use24HourTime ? hour : '6'}`, 'HH')
+      .replace(`${isLocale24HourTime ? hour : '6'}`, 'HH')
       .replace(`${minute}`, 'MM')
       .replace(`${second}`, 'SS')
       .replace(`${milliseconds}`, 'LLL');

--- a/src/components/form/date-time/date-time-functions.ts
+++ b/src/components/form/date-time/date-time-functions.ts
@@ -14,6 +14,7 @@ import {
   parseISO,
   parse,
 } from 'date-fns';
+import { TimeFormatType } from "./date-time-types.ts";
 
 export type DayType = { dayValue: Date | null; isCurrent: boolean };
 
@@ -221,6 +222,20 @@ export function parseDate(dateValue: string, locale?: Locale) {
     localDate = parse(dateValue, 'p', new Date(), { locale });
     if (!isNaN(localDate.valueOf())) return localDate;
 
+    if (!locale) {
+      localDate = parse(dateValue, 'HH:mm', new Date());
+      if (!isNaN(localDate.valueOf())) return localDate;
+
+      localDate = parse(dateValue, 'hh:mm a..aaa', new Date());
+      if (!isNaN(localDate.valueOf())) return localDate;
+
+      localDate = parse(dateValue, 'HH:mm:ss', new Date());
+      if (!isNaN(localDate.valueOf())) return localDate;
+
+      localDate = parse(dateValue, 'hh:mm:ss a..aaa', new Date());
+      if (!isNaN(localDate.valueOf())) return localDate;
+    }
+
     return undefined;
   }
 
@@ -238,4 +253,35 @@ export function parseDateRange(dateRangeValue: string, locale?: Locale) {
   if (!dateValue2) return undefined;
 
   return [dateValue1, dateValue2];
+}
+
+export function getHoursByFormat(format: TimeFormatType) {
+  return format === TimeFormatType.TwelveHour
+    ? ['12', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11']
+    : [
+      '00',
+      '01',
+      '02',
+      '03',
+      '04',
+      '05',
+      '06',
+      '07',
+      '08',
+      '09',
+      '10',
+      '11',
+      '12',
+      '13',
+      '14',
+      '15',
+      '16',
+      '17',
+      '18',
+      '19',
+      '20',
+      '21',
+      '22',
+      '23',
+    ];
 }

--- a/src/components/form/date-time/date-time-time-selector.component.tsx
+++ b/src/components/form/date-time/date-time-time-selector.component.tsx
@@ -8,6 +8,7 @@ import { IconSize } from '../../common/beesoft-icon/beesoft-icon.props.ts';
 import { Button } from '../../navigation/buttons/button/button.component.tsx';
 import { DateSelectorType, TimeConstraints, TimeFormatType } from './date-time-types';
 import { DateTimeActionType, DateTimeReducerAction } from './date-time.reducer';
+import { getHoursByFormat } from "./date-time-functions.ts";
 
 export interface DateTimeTimeSelectorProps {
   viewDate: Date;
@@ -29,36 +30,7 @@ const DateTimeTimeSelector = ({
   dispatcher,
 }: DateTimeTimeSelectorProps) => {
   const maximumHour = useRef(timeFormat === TimeFormatType.TwelveHour ? 11 : 23);
-  const hours = useRef<string[]>(
-    timeFormat === TimeFormatType.TwelveHour
-      ? ['12', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11']
-      : [
-          '00',
-          '01',
-          '02',
-          '03',
-          '04',
-          '05',
-          '06',
-          '07',
-          '08',
-          '09',
-          '10',
-          '11',
-          '12',
-          '13',
-          '14',
-          '15',
-          '16',
-          '17',
-          '18',
-          '19',
-          '20',
-          '21',
-          '22',
-          '23',
-        ]
-  );
+  const hours = useRef<string[]>(getHoursByFormat(timeFormat));
   const minutes = useRef<string[]>(generateNumberArray(0, 59, (value) => value.toString().padStart(2, '0')));
   const ampm = useRef<string[]>(['AM', 'PM']);
   const savedViewDate = useRef(cloneDeep(viewDate));
@@ -89,6 +61,10 @@ const DateTimeTimeSelector = ({
       }
     }
   }, [viewDate]);
+
+  useEffect(() => {
+    hours.current = getHoursByFormat(timeFormat);
+  }, [timeFormat]);
 
   const increaseHour = () => {
     const incrementAmount = timeConstraints?.hours?.step || 1;

--- a/src/components/form/date-time/date-time.component.stories.tsx
+++ b/src/components/form/date-time/date-time.component.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { BeeSoftProvider } from 'common/contexts/beesoft.context.tsx';
 import { forceAssert } from '../../common-functions.ts';
 import { Button } from '../../navigation/buttons/button/button.component.tsx';
-import { CalendarIconPosition, DateFormatType, DateSelectionType } from './date-time-types.ts';
+import { CalendarIconPosition, DateFormatType, DateSelectionType, TimeFormatType } from './date-time-types.ts';
 import { DateTime } from './date-time.component.tsx';
 import { DateTimeInputTemplateProps, DateTimeProps, DateTimeWrapperTemplate } from './date-time.props.ts';
 
@@ -299,6 +299,17 @@ export const FormattedTimeInput: Story = {
   args: {
     label: 'Time',
     dateSelection: DateSelectionType.TimeOnly,
+    useFormattedInput: true,
+    onChange: action('onChange'),
+  },
+  render: (args) => <Template {...args} />,
+};
+
+export const FormattedForced24TimeInput: Story = {
+  args: {
+    label: 'Time',
+    dateSelection: DateSelectionType.TimeOnly,
+    timeFormat: TimeFormatType.TwentyFourHour,
     useFormattedInput: true,
     onChange: action('onChange'),
   },

--- a/src/components/form/date-time/date-time.component.tsx
+++ b/src/components/form/date-time/date-time.component.tsx
@@ -52,6 +52,7 @@ const DateTime = ({
   className,
   dateSelection = DateSelectionType.DateTime,
   dateFormat,
+  timeFormat,
   timeConstraints,
   icon,
   iconPosition = CalendarIconPosition.Right,
@@ -80,7 +81,7 @@ const DateTime = ({
   const inputRef = useRef<ContentEditableInputRef>(null);
   const formattedInputRef = useRef<FormattedInputRef>(null);
 
-  const [inputFormat, use24HourTime] = useGetDateTimeFormat(dateSelection, localeCode);
+  const [inputFormat, use24HourTime] = useGetDateTimeFormat(dateSelection, localeCode, timeFormat);
   const dateLocale = useDateLocale(language.current);
 
   const contextProps = useRef<DateTimeContextProps>({
@@ -122,7 +123,7 @@ const DateTime = ({
   }, [value, loadedLocale.current]);
 
   useEffect(() => {
-    if (use24HourTime) {
+    if (use24HourTime !== undefined) {
       dispatcher({
         type: DateTimeActionType.SetTimeFormat,
         timeFormat: use24HourTime ? TimeFormatType.TwentyFourHour : TimeFormatType.TwelveHour,
@@ -168,7 +169,7 @@ const DateTime = ({
   const initialState: DateTimeState = {
     currentSelector: getDateSelector(),
     currentViewDate: new Date(),
-    timeFormat: TimeFormatType.TwelveHour,
+    timeFormat: timeFormat === undefined ? TimeFormatType.TwelveHour : timeFormat,
     dateInitialized: false,
   };
 
@@ -204,8 +205,11 @@ const DateTime = ({
     if (value) {
       const dateValue =
         dateSelectionRef.current !== DateSelectionType.DateRange
-          ? parseDate(value, loadedLocale.current)
+          ? !(dateSelectionRef.current === DateSelectionType.TimeOnly && timeFormat !== undefined)
+            ? parseDate(value, loadedLocale.current)
+            : parseDate(value)
           : parseDateRange(value, loadedLocale.current);
+
       if (dateValue) {
         if (isValidDate) {
           const isValid = !Array.isArray(dateValue)
@@ -234,7 +238,9 @@ const DateTime = ({
   const onDateStringChange = (dateString: string) => {
     const inputDate =
       dateSelectionRef.current !== DateSelectionType.DateRange
-        ? parseDate(dateString, loadedLocale.current)
+        ? !(dateSelectionRef.current === DateSelectionType.TimeOnly && timeFormat !== undefined)
+          ? parseDate(dateString, loadedLocale.current)
+          : parseDate(dateString)
         : parseDateRange(dateString, loadedLocale.current);
 
     if (inputDate) {

--- a/src/components/form/date-time/date-time.props.ts
+++ b/src/components/form/date-time/date-time.props.ts
@@ -7,7 +7,7 @@ import {
   DateFormatType,
   DateScrollerType,
   DateSelectionType,
-  TimeConstraints,
+  TimeConstraints, TimeFormatType,
 } from './date-time-types.ts';
 import { Locale } from 'date-fns';
 import { DayType } from './date-time-functions.ts';
@@ -60,6 +60,7 @@ export interface DateTimeProps extends FormInputControl<string | TypeOrArray<Dat
   locale?: string;
   dateSelection?: DateSelectionType;
   dateFormat?: DateFormatType;
+  timeFormat?: TimeFormatType;
   timeConstraints?: TimeConstraints;
   icon?: React.JSX.Element;
   iconPosition?: CalendarIconPosition;

--- a/src/components/form/date-time/hooks/get-date-time-format.hook.ts
+++ b/src/components/form/date-time/hooks/get-date-time-format.hook.ts
@@ -1,21 +1,22 @@
 import { useEffect, useRef, useState } from 'react';
 import { InputFormat } from '../../inputs/formatted-input/input-format.interfaces';
 import { DateTimeFormatCreator } from '../date-time-format-creator';
-import { DateSelectionType } from '../date-time-types';
+import { DateSelectionType, TimeFormatType } from '../date-time-types';
 
 const useGetDateTimeFormat = (
   dateSelection: DateSelectionType,
-  localeCode?: string
+  localeCode?: string,
+  timeFormat?: TimeFormatType
 ): [InputFormat | undefined, boolean | undefined] => {
   const [inputFormat, setInputFormat] = useState<InputFormat>();
   const formatCreator = useRef<DateTimeFormatCreator>(undefined);
 
   useEffect(() => {
     if (localeCode && !inputFormat) {
-      formatCreator.current = new DateTimeFormatCreator(dateSelection, localeCode);
+      formatCreator.current = new DateTimeFormatCreator(dateSelection, localeCode, timeFormat);
       setInputFormat(formatCreator.current.createInputFormat());
     }
-  }, [localeCode]);
+  }, [localeCode, timeFormat]);
 
   return [inputFormat, formatCreator.current?.is24HourTime];
 };


### PR DESCRIPTION
Added a `timeFormat` property to allow the user to set 12 or 24 hour formats outside the locale's settings.